### PR TITLE
added default values from php.ini file if none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ Once the file is included, it will create `mysql_*` function if they don't alrea
 - Calls to `is_resource()` and `get_resource_type()` on MySQL connections and results will fail as these are now their `mysqli` equivalents.
 -Some errors are now from `ext/mysqli`, and others are `E_USER_WARNING` instead of `E_WARNING`.
 - Column lengths reported by `mysql_field_len()` assume latin1
+- If no host, username, password parameter is provided when using the `mysql_*` functions, the default values from the corresponding mysqli settings from php.ini file will be used
+(e.g. mysqli.default_host, mysqli.default_user, mysqli.default_pw)

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -17,6 +17,15 @@ namespace {
             if ($new !== false) {
                 trigger_error('Argument $new is no longer supported in PHP > 7', E_USER_WARNING);
             }
+            if (!$hostname) {
+                $hostname = ini_get("mysqli.default_host");
+            }
+            if (!$username) {
+                $username = ini_get("mysqli.default_user");
+            }
+            if (!$password) {
+                $password = ini_get("mysqli.default_pw");
+            }
 
             $hash = sha1($hostname . $username . $flags);
             if ($hostname{1} != ':' && isset(\Dshafik\MySQL::$connections[$hash])) {


### PR DESCRIPTION
Hi,

thanks for this nice wrapper, as I do not call those functions with user and password all the time (because I've stored my defaults here in the php.ini file) I would need to have those defaults applied if nothing else is provided when calling a connect.
