### PR TITLE
Fix mysql_fetch_object return value

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -315,11 +315,18 @@ namespace {
                 // @codeCoverageIgnoreEnd
             }
 
+            $object = null;
             if ($class == null) {
-                return mysqli_fetch_object($result);
+                $object = mysqli_fetch_object($result);
+            } else {
+                $object = mysqli_fetch_object($result, $class, $params);
             }
 
-            return mysqli_fetch_object($result, $class, $params);
+            if($object == null) {
+                return false;
+            }
+            
+            return $object;
         }
 
         function mysql_data_seek($result, $offset)


### PR DESCRIPTION
The methods [`mysql_fetch_object`](http://php.net/manual/en/function.mysql-fetch-object.php) and [`mysqli_fetch_object`](http://php.net/manual/en/mysqli-result.fetch-object.php) have different return values, if there is no more result in the sql-query. Therefore the **null**-Return value of `mysqli` needs to be matched to the **false**-Return value of `mysql`.
