### PR TITLE
Fix mysql_fetch_assoc return value

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -304,7 +304,12 @@ namespace {
                 return false;
                 // @codeCoverageIgnoreEnd
             }
-            return mysqli_fetch_assoc($result);
+            $row = mysqli_fetch_assoc($result);
+            if ($row == null) {
+                return false;
+            }
+
+            return $row;
         }
 
         function mysql_fetch_object($result, $class = null, array $params = []) /* : object|null */


### PR DESCRIPTION
The methods [`mysql_fetch_assoc`](http://php.net/manual/en/function.mysql-fetch-array.php) and [`mysqli_fetch_assoc`](http://php.net/manual/en/mysqli-result.fetch-assoc.php) have different return values, if there is no more result in the sql-query. Therefore the **null**-Return value of `mysqli` needs to be matched to the **false**-Return value of `mysql`.
