### PR TITLE
mysql_connect should return FALSE when mysqli_connect fails.

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -38,7 +38,11 @@ namespace {
             }
 
             if ($flags === 0) {
-                \Dshafik\MySQL::$last_connection = $conn = mysqli_connect($hostname, $username, $password);
+                $conn = mysqli_connect($hostname, $username, $password);
+                if (!$conn instanceof mysqli) {
+                    return false;
+                }
+                \Dshafik\MySQL::$last_connection = $conn;
                 $conn->hash = $hash;
                 \Dshafik\MySQL::$connections[$hash] = ['refcount' => 1, 'conn' => $conn];
 
@@ -800,7 +804,7 @@ namespace Dshafik {
                     $esc = $char;
                     break;
             }
-            
+
             return $esc;
         }
     }


### PR DESCRIPTION
Using result of `mysqli_connect` call without type check can hide connection errors so code like this

``` php
mysql_connect($hostname, $username, $password) or die("Could not connect to MySQL");
```

will not work as expected.

This PR fixes problem by returning `false` when `mysqli_connect` return something other than an instance of `mysqli`.
