### PR TITLE
Added the result type to the mysql_fetch_array function

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -306,14 +306,14 @@ namespace {
             return mysqli_fetch_row($result) ?: false;
         }
 
-        function mysql_fetch_array($result)
+        function mysql_fetch_array($result, $resulttype = MYSQL_BOTH)
         {
             if (\Dshafik\MySQL::checkValidResult($result, __FUNCTION__)) {
                 // @codeCoverageIgnoreStart
                 return false;
                 // @codeCoverageIgnoreEnd
             }
-            return mysqli_fetch_array($result) ?: false;
+            return mysqli_fetch_array($result, $resulttype) ?: false;
         }
 
         function mysql_fetch_assoc($result) /* : array|null */

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -306,14 +306,14 @@ namespace {
             return mysqli_fetch_row($result) ?: false;
         }
 
-        function mysql_fetch_array($result, $resulttype = MYSQL_BOTH)
+        function mysql_fetch_array($result, $resultType = MYSQL_BOTH)
         {
             if (\Dshafik\MySQL::checkValidResult($result, __FUNCTION__)) {
                 // @codeCoverageIgnoreStart
                 return false;
                 // @codeCoverageIgnoreEnd
             }
-            return mysqli_fetch_array($result, $resulttype) ?: false;
+            return mysqli_fetch_array($result, $resultType) ?: false;
         }
 
         function mysql_fetch_assoc($result) /* : array|null */

--- a/tests/MySqlShimTest.php
+++ b/tests/MySqlShimTest.php
@@ -615,7 +615,7 @@ class MySqlShimTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider mysql_fetch_DataProvider
      */
-    public function test_mysql_fetch($function, $results)
+    public function test_mysql_fetch($function, $results, $resultType = null)
     {
         $this->getConnection("shim_test");
 
@@ -625,7 +625,7 @@ class MySqlShimTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(sizeof($results), mysql_num_rows($result));
 
         $i = 0;
-        while ($row = $function($result)) {
+        while ($row = $function($result, $resultType)) {
             $this->assertEquals($results[$i], $row);
             $i++;
         }

--- a/tests/MySqlShimTest.php
+++ b/tests/MySqlShimTest.php
@@ -930,8 +930,18 @@ class MySqlShimTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 'function' => 'mysql_fetch_array',
+                'results' => $assoc,
+                'resulttype' => MYSQL_ASSOC
+            ],
+            [
+                'function' => 'mysql_fetch_array',
                 'results' => $array,
-                'resulttype' => 3
+                'resulttype' => MYSQL_BOTH
+            ],
+            [
+                'function' => 'mysql_fetch_array',
+                'results' => $numeric,
+                'resulttype' => MYSQL_NUM
             ],
             [
                 'function' => 'mysql_fetch_assoc',

--- a/tests/MySqlShimTest.php
+++ b/tests/MySqlShimTest.php
@@ -930,7 +930,8 @@ class MySqlShimTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 'function' => 'mysql_fetch_array',
-                'results' => $array
+                'results' => $array,
+                'resulttype' => 3
             ],
             [
                 'function' => 'mysql_fetch_assoc',


### PR DESCRIPTION
I've added the option to give the result type of the 'mysql_fetch_array' function.

I'm not really sure if the test is adjusted the right way.
