### PR TITLE
Clarify when including 5.6 will do nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or, clone/download this repo, and include `mysql.php` in your project.
 
 ## Usage
 
-Once the file is included, it will create `mysql_*` function if they don't already exist. _**You may safely include the file in a PHP 5.6 project**_, it will do nothing.
+Once the file is included, it will create `mysql_*` functions if they don't already exist. _**You may safely include the file in a PHP 5.6 project**_, it will do nothing if ext/mysql is already installed. 
 
 ## Caveats
 


### PR DESCRIPTION
Alternatively, the entire README could be updated with less focus on PHP 7, and more on ext/mysql vs ext/mysqli.