### PR TITLE
#24

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -25,12 +25,6 @@ namespace {
             trigger_error('php7-mysql-shim: ext/mysqli is required', E_USER_ERROR);
         }
 
-        trigger_error(
-            "php7-mysql-shim: The mysql extension is deprecated "
-            . "and was removed in the PHP 7.0: use mysqli or PDO instead.",
-            E_USER_DEPRECATED
-        );
-
         define('MYSQL_ASSOC', 1);
         define('MYSQL_NUM', 2);
         define('MYSQL_BOTH', 3);
@@ -58,6 +52,12 @@ namespace {
             if (null === $password) {
                 $password = ini_get('mysqli.default_pw') ?: null;
             }
+            trigger_error(
+                "php7-mysql-shim: The mysql extension is deprecated "
+                . "and was removed in the PHP 7.0: use mysqli or PDO instead.",
+                E_USER_DEPRECATED
+            );
+
 
             $hash = sha1($hostname . $username . $flags);
             /* persistent connections start with p: */


### PR DESCRIPTION
- Moved the trigger_error warning until after a connection has been attempted.  This way simply including the file does not automaticaly break a build, only when a user attempts to use a deprecated function will it cause problems.

Signed-off-by: Michael Soileau <webart.video@gmail.com>