### PR TITLE
Fix call to `mysqli_ping`

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -512,7 +512,7 @@ namespace {
 
         function mysql_ping(\mysqli $link = null)
         {
-            return mysqli_ping($link);
+            return mysqli_ping(\Dshafik\MySQL::getConnection($link));
         }
 
         function mysql_get_client_info(\mysqli $link = null)


### PR DESCRIPTION
All of the other `mysqli_` functions with the `$link` as an argument used `\Dshafik\MySQL::getConnection($link)`. The call to `mysqli_ping` did not.