### PR TITLE
Fixed: No entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,5 @@ RUN mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-
 EXPOSE 3306
 CMD ["mysqld"]


### PR DESCRIPTION
File not found break `docker build .`