### PR TITLE
Handle custom ports defined in the hostname

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -61,9 +61,15 @@ namespace {
                 return \Dshafik\MySQL::$connections[$hash]['conn'];
             }
 
+            if (strpos($hostname, ':') !== false) {
+                list($hostname, $port) = explode(':', $hostname, 2);
+            } else {
+                $port = null;
+            }
+
             /* No flags, means we can use mysqli_connect() */
             if ($flags === 0) {
-                $conn = mysqli_connect($hostname, $username, $password);
+                $conn = mysqli_connect($hostname, $username, $password, '', $port);
                 if (!$conn instanceof mysqli) {
                     return false;
                 }
@@ -84,7 +90,7 @@ namespace {
                     $username,
                     $password,
                     '',
-                    null,
+                    $port,
                     '',
                     $flags
                 );

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -62,7 +62,7 @@ namespace {
             }
 
             /* A custom port can be specified by appending the hostname with :{port} e.g. hostname:3307 */
-            if (preg_match('/^(.+):([\d]+)$/', $hostname, $port_matches) === 1) {
+            if (preg_match('/^(.+):([\d]+)$/', $hostname, $port_matches) === 1 && $port_matches[1] !== "p") {
                 $hostname = $port_matches[1];
                 $port = (int) $port_matches[2];
             } else {

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -61,8 +61,10 @@ namespace {
                 return \Dshafik\MySQL::$connections[$hash]['conn'];
             }
 
-            if (strpos($hostname, ':') !== false) {
-                list($hostname, $port) = explode(':', $hostname, 2);
+            /* A custom port can be specified by appending the hostname with :{port} e.g. hostname:3307 */
+            if (preg_match('/^(.+):([\d]+)$/', $hostname, $port_matches) === 1) {
+                $hostname = $port_matches[1];
+                $port = (int) $port_matches[2];
             } else {
                 $port = null;
             }


### PR DESCRIPTION
Non-default ports are defined as part of the hostname when using mysql_connect however they are defined using an argument in the MySQLi library.