### PR TITLE
Fix mysqli_fetch_field consistency

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -407,7 +407,16 @@ namespace {
                 return false;
                 // @codeCoverageIgnoreEnd
             }
-            return mysqli_fetch_field($result);
+            $res = mysqli_fetch_field($result);
+            $res->not_null = ($res->flags & MYSQLI_NOT_NULL_FLAG) ? 1 : 0;
+            $res->primary_key = ($res->flags & MYSQLI_PRI_KEY_FLAG ) ? 1 : 0;
+            $res->unique_key = ($res->flags & MYSQLI_UNIQUE_KEY_FLAG ) ? 1 : 0;
+            $res->multiple_key = ($res->flags & MYSQLI_MULTIPLE_KEY_FLAG ) ? 1 : 0;
+            $res->numeric = ($res->flags & MYSQLI_NUM_FLAG ) ? 1 : 0;
+            $res->blob = ($res->flags & MYSQLI_BLOB_FLAG ) ? 1 : 0;
+            $res->unsigned = ($res->flags & MYSQLI_UNSIGNED_FLAG ) ? 1 : 0;
+            $res->zerofill = ($res->flags & MYSQLI_ZEROFILL_FLAG ) ? 1 : 0;
+            return $res;
         }
 
         function mysql_field_seek($result, $field)


### PR DESCRIPTION
Hello @dshafik ,

I'd like to merge @GerMalaz' patch exposed in #38 (with a correction on the _unsigned_ key) but I was not able to run the actual test suite (and write my own). Here's the output:

```bash
benoit@MacBook.local [master] @/php7-mysql-shim$ composer run test
> phpunit

Deprecated: The each() function is deprecated. This message will be suppressed on further calls in /Users/benoit/PhpstormProjects/php7-mysql-shim/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /Users/benoit/PhpstormProjects/php7-mysql-shim/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
PHPUnit 1.0.0beta3-1-g3775315 by Sebastian Bergmann and contributors.

Runtime:        PHP 7.4.0
Configuration:  /Users/benoit/PhpstormProjects/php7-mysql-shim/phpunit.xml.dist
Warning:        The Xdebug extension is not loaded
                No code coverage will be generated.

=> Finding binaries
=> Running Docker Container: 03ec08e91fa5a7761918c299a4cd7e77d5fb20a4482e2a346eefb54c041a6619
=> Finding MySQL Host: 0.0.0.0:32769
=> Waiting on mysqld to start:
                                                                  
  [Symfony\Component\Process\Exception\ProcessTimedOutException]  
  The process "phpunit" exceeded the timeout of 300 seconds.      
                                                                  

run-script [--timeout TIMEOUT] [--dev] [--no-dev] [-l|--list] [--] [<script>] [<args>]...
```

And nothing happens after 5 minutes. Any ideas?