### PR TITLE
Adds backtrace for illegal argument supplied warning

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -734,16 +734,24 @@ namespace Dshafik {
         public static function checkValidResult($result, $function)
         {
             if (!($result instanceof \mysqli_result)) {
+                $type = strtolower(gettype($result));
+                $file = "";
+                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+                if (isset($backtrace[1], $backtrace[1]['file'], $backtrace[1]['line'])) {
+                    $caller = $backtrace[1];
+                    $file = $caller['file'] . ':' . $caller['line'];
+                }
+
                 if ($function !== 'mysql_fetch_object') {
                     trigger_error(
-                        $function . '() expects parameter 1 to be resource, ' . strtolower(gettype($result)) . ' given',
+                        "$function() expects parameter 1 to be resource, $type given on $file",
                         E_USER_WARNING
                     );
                 }
 
                 if ($function === 'mysql_fetch_object') {
                     trigger_error(
-                        $function . '(): supplied argument is not a valid MySQL result resource',
+                        "$function(): supplied argument is not a valid MySQL result resource on $file",
                         E_USER_WARNING
                     );
                 }

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -737,10 +737,20 @@ namespace Dshafik {
                 $type = strtolower(gettype($result));
                 $file = "";
                 $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-                if (isset($backtrace[1], $backtrace[1]['file'], $backtrace[1]['line'])) {
-                    $caller = $backtrace[1];
-                    $file = $caller['file'] . ':' . $caller['line'];
-                }
+                $backtraceIndex = 0;
+
+                /**
+                 * Iterate through backtrace until find an backtrace with origin
+                 * Some methods may not leave file and line metadata like call_user_func_array and __call
+                 */
+                do {
+                    $currentBacktrace = $backtrace[$backtraceIndex];
+                    $callerHasFileAndLine = isset($currentBacktrace['file'], $currentBacktrace['line']);
+
+                    if ($callerHasFileAndLine && $currentBacktrace['file'] != __FILE__) {
+                        $file = $currentBacktrace['file'] . ':' . $currentBacktrace['line'];
+                    }
+                } while ($backtraceIndex++ < count($backtrace) && $file == "");
 
                 if ($function !== 'mysql_fetch_object') {
                     trigger_error(

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -740,7 +740,7 @@ namespace Dshafik {
                 $backtraceIndex = 0;
 
                 /**
-                 * Iterate through backtrace until find an backtrace with origin
+                 * Iterate through backtrace until finding a backtrace with an origin
                  * Some methods may not leave file and line metadata like call_user_func_array and __call
                  */
                 do {

--- a/tests/MySqlShimTest.php
+++ b/tests/MySqlShimTest.php
@@ -695,6 +695,13 @@ class MySqlShimTest extends \PHPUnit\Framework\TestCase
         call_user_func($function, null);
     }
 
+    public function test_mysql_check_valid_result_backtraces_here()
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage(__FUNCTION__ . "() expects parameter 1 to be resource, boolean given on " . __FILE__ . ':' .  (__LINE__ + 1));
+        \Dshafik\MySQL::checkValidResult(false, __FUNCTION__);
+    }
+
     /**
      * @dataProvider mysql_fetch_DataProvider
      */

--- a/tests/MySqlShimTest.php
+++ b/tests/MySqlShimTest.php
@@ -688,8 +688,10 @@ class MySqlShimTest extends \PHPUnit\Framework\TestCase
 
         if ($args !== array()) {
             array_unshift($args, null);
+            $this->expectWarningMessageMatches('@' . __FILE__ . ':' .  (__LINE__ + 1) . '@');
             call_user_func_array($function, $args);
         }
+        $this->expectWarningMessageMatches('@' . __FILE__ . ':' .  (__LINE__ + 1) . '@');
         call_user_func($function, null);
     }
 


### PR DESCRIPTION
When a query crashes and the result is used without any kind of validation, the emitted warning points to the library's code, this pull request adds information about where it is called.

The tests keep passing but I didn't add any because I'm not sure if needed and how.

Warning output before:

```
[2020-10-22T14:28:40.847330-03:00] app.WARNING: E_USER_WARNING: mysql_fetch_array() expects parameter 1 to be resource, boolean given {"code":512,"message":"mysql_fetch_array() expects parameter 1 to be resource, boolean given","file":"/var/www/html/vendor/dshafik/php7-mysql-shim/lib/mysql.php","line":718} []
```

After:

```
[2020-10-22T14:30:16.775115-03:00] app.WARNING: E_USER_WARNING: mysql_fetch_array() expects parameter 1 to be resource, boolean given on /var/www/html/public/xxx.php:1234 {"code":512,"message":"mysql_fetch_array() expects parameter 1 to be resource, boolean given on /var/www/html/public/xxx.php:1234","file":"/var/www/html/vendor/dshafik/php7-mysql-shim/lib/mysql.php","line":721} []
```