### PR TITLE
Fixed stdClass constructor call in mysql_fetch_object()

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -384,8 +384,10 @@ namespace {
                 // @codeCoverageIgnoreEnd
             }
 
-            if ($class === null || $class === 'stdClass') {
+            if ($class === null) {
                 $object = mysqli_fetch_object($result);
+            } else if (!method_exists($class, '__construct')) {
+                $object = mysqli_fetch_object($result, $class);
             } else {
                 $object = mysqli_fetch_object($result, $class, $params);
             }

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -384,7 +384,7 @@ namespace {
                 // @codeCoverageIgnoreEnd
             }
 
-            if ($class === null) {
+            if ($class === null || $class === 'stdClass') {
                 $object = mysqli_fetch_object($result);
             } else {
                 $object = mysqli_fetch_object($result, $class, $params);


### PR DESCRIPTION
Fixed error *"stdClass does not have a constructor hence you cannot use ctor_params"* (tested in PHP 7.0.33) when explicitly passing `"stdClass"` instead of `null` to `mysql_fetch_object()`.